### PR TITLE
Fix Calculation for next30days Method

### DIFF
--- a/src/main/java/programmerzamannow/restful/service/AuthService.java
+++ b/src/main/java/programmerzamannow/restful/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     }
 
     private Long next30Days() {
-        return System.currentTimeMillis() + (1000 * 60 * 24 * 30);
+        return System.currentTimeMillis() + (1000 * 60 * 60 * 24 * 30);
     }
 
     @Transactional


### PR DESCRIPTION
Fixes calculation inaccuracies in the next30days function:

**Before:**
- 1000×60×24×30 ms = 43,200,000 ms = 0.5 days

**After:**
 - 1000×60×60×24×30 ms = 2,592,000,000 ms = 30 days